### PR TITLE
Selenium 3.9.1 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<version>0.5.0</version>
 	</parent>
 	<artifactId>fitnesse-selenium-slim</artifactId>
-    <version>1.0.3</version>
+    <version>1.1.0-SNAPSHOT</version>
 	<name>fitnesse-selenium-slim</name>
 	<description>FitNesse Selenium fixture in slim format. Allows running selenium commands similar to firefox IDE plugin.</description>
 	<url>https://github.com/andreptb/fitnesse-selenium-slim</url>
@@ -36,7 +36,7 @@
 
 	<properties>
         <fitnesse.version>20161106</fitnesse.version>
-        <selenium.version>3.0.1</selenium.version>
+        <selenium.version>3.9.1</selenium.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>org.reflections</groupId>
 			<artifactId>reflections</artifactId>
-			<version>0.9.10</version>
+			<version>0.9.11</version>
 		</dependency>
         <dependency>
             <groupId>one.util</groupId>
@@ -87,11 +87,6 @@
 			<artifactId>maven-classpath-plugin</artifactId>
 			<version>1.9</version>
 			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-            <version>18.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>

--- a/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
+++ b/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
@@ -903,6 +903,8 @@ public class SeleniumFixture {
 				if (parsedLocator.getBy() instanceof ByWebElement) {
 					// Check with the remote if it is still there by trying to execute command which has no side effects
 					driver.findElement(parsedLocator.getBy()).isDisplayed();
+					// If no exception was thrown it is still there
+					elementFound = true;
 				} else {
 					elementFound = this.dialogHelper.present(driver, parsedLocator) || driver.findElement(parsedLocator.getBy()) != null;
 				}

--- a/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
+++ b/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
@@ -901,11 +901,8 @@ public class SeleniumFixture {
 
 			try {
 				if (parsedLocator.getBy() instanceof ByWebElement) {
-					WebElement elm = driver.findElement(parsedLocator.getBy());
-					if (elm != null) {
-						// check with the remove if it is still there
-						elm.isDisplayed();
-					}
+					// Check with the remote if it is still there by trying to execute command which has no side effects
+					driver.findElement(parsedLocator.getBy()).isDisplayed();
 				} else {
 					elementFound = this.dialogHelper.present(driver, parsedLocator) || driver.findElement(parsedLocator.getBy()) != null;
 				}

--- a/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
+++ b/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
@@ -882,11 +882,11 @@ public class SeleniumFixture {
 		});
 	}
 
-
 	private String acceptConfigReturnPrevious(String newConfig, boolean oldValue, Consumer<Boolean> setter) {
 		setter.accept(this.fitnesseMarkup.onOrOffToBoolean(newConfig));
 		return this.fitnesseMarkup.booleanToOnOrOff(oldValue);
 	}
+
 	/**
 	 * <p>
 	 * <code>
@@ -900,7 +900,6 @@ public class SeleniumFixture {
 	public String stopTestOnFirstFailure(String shouldStop) {
 		return acceptConfigReturnPrevious(shouldStop, SeleniumFixture.WEB_DRIVER.getStopTestOnFirstFailure(), SeleniumFixture.WEB_DRIVER::setStopTestOnFirstFailure);
 	}
-
 
 	/**
 	 * <p>
@@ -919,7 +918,7 @@ public class SeleniumFixture {
 		boolean dryRun = this.fitnesseMarkup.onOrOffToBoolean(enableDryRun);
 		String dryRunWindow = SeleniumFixture.WEB_DRIVER.getDryRunWindow();
 		boolean isDryRunAlreadyEnabled = StringUtils.isNotBlank(dryRunWindow);
-		if(!dryRun) {
+		if (!dryRun) {
 			SeleniumFixture.WEB_DRIVER.setDryRunWindow(null);
 			if (isDryRunAlreadyEnabled) {
 				selectWindow(dryRunWindow);
@@ -927,14 +926,14 @@ public class SeleniumFixture {
 			}
 			return this.fitnesseMarkup.booleanToOnOrOff(isDryRunAlreadyEnabled);
 		}
-		if(isDryRunAlreadyEnabled) {
+		if (isDryRunAlreadyEnabled) {
 			return FitnesseMarkup.ON_VALUE;
 		}
 		SeleniumFixture.WEB_DRIVER.doWhenAvailable(null, (driver, parsedLocator) -> {
 			Collection<String> previousHandles = driver.getWindowHandles();
 			openWindow(driver, SeleniumFixture.BLANK_PAGE);
 			Optional<String> dryRunWindowId = driver.getWindowHandles().stream().filter(w -> !previousHandles.contains(w)).findFirst();
-			if(!dryRunWindowId.isPresent()) {
+			if (!dryRunWindowId.isPresent()) {
 				throw new StopTestWithWebDriverException("Unable to create blank window to run test in dry run mode");
 			}
 			SeleniumFixture.WEB_DRIVER.setDryRunWindow(dryRunWindowId.get());

--- a/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
+++ b/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
@@ -56,8 +56,7 @@ public class SeleniumFixture {
 	private static final String BLANK_PAGE = "about:blank";
 
 	/**
-	 * Instance that wraps {@link WebDriver} providing utility methods to manipulate elements and such. Attribute is
-	 * static to keep state between table invocations
+	 * Instance that wraps {@link WebDriver} providing utility methods to manipulate elements and such. Attribute is static to keep state between table invocations
 	 */
 	private static WebDriverHelper WEB_DRIVER = new WebDriverHelper();
 
@@ -87,12 +86,9 @@ public class SeleniumFixture {
 	 * Registers the DRIVER to further execute selenium commands
 	 *
 	 * @see #startBrowserWith(String, String)
-	 * @param browser
-	 *            The browser to be used
-	 * @throws ReflectiveOperationException
-	 *             if remote driver class cannot be instantiated
-	 * @throws IOException
-	 *             if IO error occurs if invalid URL is used when connecting to remote drivers
+	 * @param browser The browser to be used
+	 * @throws ReflectiveOperationException if remote driver class cannot be instantiated
+	 * @throws IOException if IO error occurs if invalid URL is used when connecting to remote drivers
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean startBrowser(String browser) throws ReflectiveOperationException, IOException {
@@ -105,23 +101,16 @@ public class SeleniumFixture {
 	 * | start browser | <i>browser</i> | with | <i>capabilities</i> |
 	 * </code>
 	 * </p>
-	 * Registers the DRIVER to further execute selenium commands. Capabilities should be informed in the following
-	 * format:
+	 * Registers the DRIVER to further execute selenium commands. Capabilities should be informed in the following format:
 	 * <p>
 	 * name='some test' platform='LINUX' version='xx'
 	 * </p>
-	 * This format was used instead of regular json format since FitNesse uses brackets for variables. Quotes between
-	 * values must be used
+	 * This format was used instead of regular json format since FitNesse uses brackets for variables. Quotes between values must be used
 	 *
-	 * @param browser
-	 *            The browser to be used
-	 * @param capabilities
-	 *            Usually used to configure remote driver, but some local driver also uses. For example: name='some
-	 *            test' platform='LINUX' version='xx'
-	 * @throws ReflectiveOperationException
-	 *             if remote driver class cannot be instantiated
-	 * @throws IOException
-	 *             if IO error occurs if invalid URL is used when connecting to remote drivers
+	 * @param browser The browser to be used
+	 * @param capabilities Usually used to configure remote driver, but some local driver also uses. For example: name='some test' platform='LINUX' version='xx'
+	 * @throws ReflectiveOperationException if remote driver class cannot be instantiated
+	 * @throws IOException if IO error occurs if invalid URL is used when connecting to remote drivers
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean startBrowserWith(String browser, String capabilities) throws ReflectiveOperationException, IOException {
@@ -134,24 +123,17 @@ public class SeleniumFixture {
 	 * | start browser | <i>browser</i> | with preferences | <i>browser preferences</i> |
 	 * </code>
 	 * </p>
-	 * Registers the DRIVER to further execute selenium commands. Preferences should be informed in the following
-	 * format:
+	 * Registers the DRIVER to further execute selenium commands. Preferences should be informed in the following format:
 	 * <p>
 	 * name='some test' platform='LINUX' version='xx'
 	 * </p>
-	 * This format was used instead of regular json format since FitNesse uses brackets for variables. Quotes between
-	 * values must be used
+	 * This format was used instead of regular json format since FitNesse uses brackets for variables. Quotes between values must be used
 	 *
-	 * @param browser
-	 *            The browser to be used
-	 * @param browserPreferences
-	 *            Allows profile configuration for some browser. At this moment supports Chrome and Firefox drivers
-	 *            (local and remote)
+	 * @param browser The browser to be used
+	 * @param browserPreferences Allows profile configuration for some browser. At this moment supports Chrome and Firefox drivers (local and remote)
 	 * @return result Boolean result indication of assertion/operation
-	 * @throws ReflectiveOperationException
-	 *             if remote driver class cannot be instantiated
-	 * @throws IOException
-	 *             if IO error occurs if invalid URL is used when connecting to remote drivers
+	 * @throws ReflectiveOperationException if remote driver class cannot be instantiated
+	 * @throws IOException if IO error occurs if invalid URL is used when connecting to remote drivers
 	 */
 	public boolean startBrowserWithPreferences(String browser, String browserPreferences) throws ReflectiveOperationException, IOException {
 		return startBrowserWithAndPreferences(browser, null, browserPreferences);
@@ -163,30 +145,20 @@ public class SeleniumFixture {
 	 * | start browser | <i>browser</i> | with | <i>capabilities</i> | and preferences | <i>browser preferences</i> |
 	 * </code>
 	 * </p>
-	 * Registers the DRIVER to further execute selenium commands. Capabilities as well as browser preferences should be
-	 * informed in the following format:
+	 * Registers the DRIVER to further execute selenium commands. Capabilities as well as browser preferences should be informed in the following format:
 	 * <p>
 	 * key1='value1' key2='value2' key3='value3'
 	 * </p>
-	 * This format was used instead of regular json format since FitNesse uses brackets for variables. Quotes between
-	 * values must be used
+	 * This format was used instead of regular json format since FitNesse uses brackets for variables. Quotes between values must be used
 	 *
-	 * @param browser
-	 *            The browser to be used
-	 * @param capabilities
-	 *            Usually used to configure remote driver, but some local driver also uses. For example: name='some
-	 *            test' platform='LINUX' version='xx'
-	 * @param browserPreferences
-	 *            Allows profile configuration for some browser. At this moment supports Chrome and Firefox drivers
-	 *            (local and remote)
+	 * @param browser The browser to be used
+	 * @param capabilities Usually used to configure remote driver, but some local driver also uses. For example: name='some test' platform='LINUX' version='xx'
+	 * @param browserPreferences Allows profile configuration for some browser. At this moment supports Chrome and Firefox drivers (local and remote)
 	 * @return result Boolean result indication of assertion/operation
-	 * @throws ReflectiveOperationException
-	 *             if remote driver class cannot be instantiated
-	 * @throws IOException
-	 *             if IO error occurs if invalid URL is used when connecting to remote drivers
+	 * @throws ReflectiveOperationException if remote driver class cannot be instantiated
+	 * @throws IOException if IO error occurs if invalid URL is used when connecting to remote drivers
 	 */
-	public boolean startBrowserWithAndPreferences(String browser, String capabilities, String browserPreferences)
-		throws ReflectiveOperationException, IOException {
+	public boolean startBrowserWithAndPreferences(String browser, String capabilities, String browserPreferences) throws ReflectiveOperationException, IOException {
 		SeleniumFixture.WEB_DRIVER.connect(browser, capabilities, browserPreferences);
 		return true;
 	}
@@ -199,8 +171,7 @@ public class SeleniumFixture {
 	 * </p>
 	 * Sets the time to wait while finding an element.
 	 *
-	 * @param timeoutInSeconds
-	 *            wait seconds to timeout
+	 * @param timeoutInSeconds wait seconds to timeout
 	 * @return previous timeout value
 	 */
 	public int setWaitTimeout(int timeoutInSeconds) {
@@ -216,8 +187,7 @@ public class SeleniumFixture {
 	 * </code>
 	 * </p>
 	 *
-	 * @return how much time the last command took to complete. Useful to ensure tests perfomance and such. Will be 0 if
-	 *         no commands were executed
+	 * @return how much time the last command took to complete. Useful to ensure tests perfomance and such. Will be 0 if no commands were executed
 	 */
 	public long lastCommandDuration() {
 		return SeleniumFixture.WEB_DRIVER.getLastActionDurationInSeconds();
@@ -231,8 +201,7 @@ public class SeleniumFixture {
 	 * </p>
 	 * Navigates to the the desired url
 	 *
-	 * @param url
-	 *            to navigate
+	 * @param url to navigate
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean open(String url) {
@@ -286,11 +255,9 @@ public class SeleniumFixture {
 	 * | check | current url | <i>url</i> | <i>url</i> |
 	 * </code>
 	 * </p>
-	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using
-	 * selenium table, please ignore this action.
+	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using selenium table, please ignore this action.
 	 *
-	 * @param expectedUrl
-	 *            that we'll wait for
+	 * @param expectedUrl that we'll wait for
 	 * @return the current page title
 	 */
 	public String currentUrl(String expectedUrl) {
@@ -312,12 +279,10 @@ public class SeleniumFixture {
 	 * | open window | <i>url</i> |
 	 * </code>
 	 * </p>
-	 * Opens a popup window with desired <i>url</i>. After opening the window, you'll need to select it using the
-	 * selectWindow command.
+	 * Opens a popup window with desired <i>url</i>. After opening the window, you'll need to select it using the selectWindow command.
 	 *
 	 * @see #selectWindow(String)
-	 * @param url
-	 *            to navigate
+	 * @param url to navigate
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean openWindow(String url) {
@@ -330,11 +295,10 @@ public class SeleniumFixture {
 	 * | select window | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Selects a popup window using a window locator; once a popup window has been selected, all commands go to that
-	 * window. Currently supports window search by nameOrHandle, title and current url
+	 * Selects a popup window using a window locator; once a popup window has been selected, all commands go to that window.
+	 * Currently supports window search by nameOrHandle, title and current url
 	 *
-	 * @param locator
-	 *            an element locator
+	 * @param locator an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean selectWindow(String locator) {
@@ -343,8 +307,7 @@ public class SeleniumFixture {
 			String currentWindow = driver.getWindowHandle();
 			for (String windowId : driver.getWindowHandles()) {
 				WebDriver window = driver.switchTo().window(windowId);
-				if (this.fitnesseMarkup.compare(parsedWindowLocator, windowId) || this.fitnesseMarkup.compare(parsedWindowLocator, window.getTitle())
-					|| this.fitnesseMarkup.compare(parsedWindowLocator, window.getCurrentUrl())) {
+				if (this.fitnesseMarkup.compare(parsedWindowLocator, windowId) || this.fitnesseMarkup.compare(parsedWindowLocator, window.getTitle()) || this.fitnesseMarkup.compare(parsedWindowLocator, window.getCurrentUrl())) {
 					return;
 				}
 			}
@@ -362,13 +325,11 @@ public class SeleniumFixture {
 	 * | select frame | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Selects a frame within the current window. (You may invoke this command multiple times to select nested frames.)
-	 * To select the parent frame, use "relative=parent" as a locator; to select the top frame, use "relative=top". You
-	 * can also select a frame by its 0-based index number; select the first frame with "index=0", or the third frame
-	 * with "index=2". Note that you can use all element locators such as <b>id</b>, <b>css</b>, <b>xpath</b> and so on
+	 * Selects a frame within the current window. (You may invoke this command multiple times to select nested frames.) To select the parent frame, use "relative=parent" as a locator; to select the
+	 * top frame, use "relative=top". You can also select a frame by its 0-based index number; select the first frame with "index=0", or the third frame with "index=2".
+	 * Note that you can use all element locators such as <b>id</b>, <b>css</b>, <b>xpath</b> and so on
 	 *
-	 * @param locator
-	 *            an element locator
+	 * @param locator an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean selectFrame(String locator) {
@@ -395,11 +356,9 @@ public class SeleniumFixture {
 	 * | check | current window | <i>windowHandle</i> | <i>windowHandle</i> |
 	 * </code>
 	 * </p>
-	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using
-	 * selenium table, please ignore this action.
+	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using selenium table, please ignore this action.
 	 *
-	 * @param expectedWindowHandle
-	 *            that we'll wait for
+	 * @param expectedWindowHandle that we'll wait for
 	 * @return the current page title
 	 */
 	public String currentWindow(String expectedWindowHandle) {
@@ -430,14 +389,11 @@ public class SeleniumFixture {
 	 * | set window size | <i>[width]x[height]</i> |
 	 * </code>
 	 * </p>
-	 * Set the size of the current window. This will change the outer window dimension, not just the view port,
-	 * synonymous to window.resizeTo() in JS.
+	 * Set the size of the current window. This will change the outer window dimension, not just the view port, synonymous to window.resizeTo() in JS.
 	 *
-	 * @param widthAndHeight
-	 *            windows size, in [width]x[height] format
+	 * @param widthAndHeight windows size, in [width]x[height] format
 	 * @return result Boolean result indication of assertion/operation
-	 * @throws IllegalArgumentException
-	 *             if widthAndHeight is malformed
+	 * @throws IllegalArgumentException if widthAndHeight is malformed
 	 */
 	public boolean setWindowSize(String widthAndHeight) {
 		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(StringUtils.EMPTY, (driver, parsedLocator) -> {
@@ -465,11 +421,9 @@ public class SeleniumFixture {
 	 * | window size |
 	 * </code>
 	 * </p>
-	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using
-	 * selenium table, please ignore this action.
+	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using selenium table, please ignore this action.
 	 *
-	 * @param expectedWindowSize
-	 *            Expected window size
+	 * @param expectedWindowSize Expected window size
 	 * @return windows size, in [width]x[height] format
 	 */
 	public String windowSize(String expectedWindowSize) {
@@ -499,11 +453,9 @@ public class SeleniumFixture {
 	 * | check | title | <i>title</i> | <i>title</i> |
 	 * </code>
 	 * </p>
-	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using
-	 * selenium table, please ignore this action.
+	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using selenium table, please ignore this action.
 	 *
-	 * @param expectedTitle
-	 *            that we'll wait for
+	 * @param expectedTitle that we'll wait for
 	 * @return the current page title
 	 */
 	public String title(String expectedTitle) {
@@ -552,12 +504,10 @@ public class SeleniumFixture {
 	 * | type | <i>value</i> |
 	 * </code>
 	 * </p>
-	 * Sets the value of the current focused input field, as though you typed it in. Can also be used to set the value
-	 * of combo boxes, check boxes, etc. In these cases, value should be the value of the option selected, not the
-	 * visible text.
+	 * Sets the value of the current focused input field, as though you typed it in.
+	 * Can also be used to set the value of combo boxes, check boxes, etc. In these cases, value should be the value of the option selected, not the visible text.
 	 *
-	 * @param value
-	 *            the value to typeIn
+	 * @param value the value to typeIn
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean type(String value) {
@@ -570,13 +520,11 @@ public class SeleniumFixture {
 	 * | type | <i>value</i> | in | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Sets the value of an input field, as though you typed it in. Can also be used to set the value of combo boxes,
-	 * check boxes, etc. In these cases, value should be the value of the option selected, not the visible text.
+	 * Sets the value of an input field, as though you typed it in.
+	 * Can also be used to set the value of combo boxes, check boxes, etc. In these cases, value should be the value of the option selected, not the visible text.
 	 *
-	 * @param value
-	 *            the value to typeIn
-	 * @param locator
-	 *            an element locator
+	 * @param value the value to typeIn
+	 * @param locator an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean typeIn(String value, String locator) {
@@ -589,17 +537,13 @@ public class SeleniumFixture {
 	 * | send keys | <i>value</i> |
 	 * </code>
 	 * </p>
-	 * Simulates keystroke events on the current focused element, as though you typed the value key-by-key. This
-	 * simulates a real user typing every character in the specified string; it is also bound by the limitations of a
-	 * real user, like not being able to type into a invisible or read only elements. This is useful for dynamic UI
-	 * widgets (like auto-completing combo boxes) that require explicit key events. Unlike the simple "type" command,
-	 * which forces the specified value into the page directly, this command will not replace the existing content. If
-	 * you want to replace the existing contents, you need to use the simple "type" command to set the value of the
-	 * field to empty string to clear the field and then the "sendKeys" command to send the keystroke for what you want
-	 * to type.
+	 * Simulates keystroke events on the current focused element, as though you typed the value key-by-key.
+	 * This simulates a real user typing every character in the specified string; it is also bound by the limitations of a real user, like not being able to type into a invisible or read only
+	 * elements. This is useful for dynamic UI widgets (like auto-completing combo boxes) that require explicit key events.
+	 * Unlike the simple "type" command, which forces the specified value into the page directly, this command will not replace the existing content. If you want to replace the existing contents, you
+	 * need to use the simple "type" command to set the value of the field to empty string to clear the field and then the "sendKeys" command to send the keystroke for what you want to type.
 	 *
-	 * @param value
-	 *            the value to typeIn
+	 * @param value the value to typeIn
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean sendKeys(String value) {
@@ -612,18 +556,14 @@ public class SeleniumFixture {
 	 * | send keys | <i>value</i> | in | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Simulates keystroke events on the specified element, as though you typed the value key-by-key. This simulates a
-	 * real user typing every character in the specified string; it is also bound by the limitations of a real user,
-	 * like not being able to type into a invisible or read only elements. This is useful for dynamic UI widgets (like
-	 * auto-completing combo boxes) that require explicit key events. Unlike the simple "type" command, which forces the
-	 * specified value into the page directly, this command will not replace the existing content. If you want to
-	 * replace the existing contents, you need to use the simple "type" command to set the value of the field to empty
-	 * string to clear the field and then the "sendKeys" command to send the keystroke for what you want to type.
+	 * Simulates keystroke events on the specified element, as though you typed the value key-by-key.
+	 * This simulates a real user typing every character in the specified string; it is also bound by the limitations of a real user, like not being able to type into a invisible or read only
+	 * elements. This is useful for dynamic UI widgets (like auto-completing combo boxes) that require explicit key events.
+	 * Unlike the simple "type" command, which forces the specified value into the page directly, this command will not replace the existing content. If you want to replace the existing contents, you
+	 * need to use the simple "type" command to set the value of the field to empty string to clear the field and then the "sendKeys" command to send the keystroke for what you want to type.
 	 *
-	 * @param value
-	 *            the value to typeIn
-	 * @param locator
-	 *            an element locator
+	 * @param value the value to typeIn
+	 * @param locator an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean sendKeysIn(String value, String locator) {
@@ -645,15 +585,12 @@ public class SeleniumFixture {
 	}
 
 	/**
-	 * When send keys is being executed in a input file=type {@link LocalFileDetector} must be configured for remote
-	 * drivers. Additionally, the file path is expanded to be absolute
+	 * When send keys is being executed in a input file=type {@link LocalFileDetector} must be configured for remote drivers. Additionally,
+	 * the file path is expanded to be absolute
 	 *
-	 * @param driver
-	 *            used to run commands
-	 * @param element
-	 *            receiving keys
-	 * @param value
-	 *            to be set to input file type
+	 * @param driver used to run commands
+	 * @param element receiving keys
+	 * @param value to be set to input file type
 	 * @return value expanded to absolute path if for input file type.
 	 */
 	private String cleanValueToSend(WebDriver driver, WebElement element, String value) {
@@ -687,11 +624,9 @@ public class SeleniumFixture {
 	 * | click | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Clicks on a link, button, checkbox or radio button. If the click action causes a new page to load (like a link
-	 * usually does), call waitForPageToLoad.
+	 * Clicks on a link, button, checkbox or radio button. If the click action causes a new page to load (like a link usually does), call waitForPageToLoad.
 	 *
-	 * @param locator
-	 *            an element locator
+	 * @param locator an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean click(String locator) {
@@ -713,18 +648,16 @@ public class SeleniumFixture {
 	 * | select | <i>optionLocator</i> |
 	 * </code>
 	 * </p>
-	 * Select an option from the currently focused drop-down using an option locator. Option locators provide different
-	 * ways of specifying options of an HTML Select element (e.g. for selecting a specific option, or for asserting that
-	 * the selected option satisfies a specification). There are several forms of Select Option Locator.
+	 * Select an option from the currently focused drop-down using an option locator.
+	 * Option locators provide different ways of specifying options of an HTML Select element (e.g. for selecting a specific option, or for asserting that the selected option satisfies a
+	 * specification). There are several forms of Select Option Locator.
 	 * <ul>
-	 * <li><b>label</b>=<i>labelPattern</i>: matches options based on their labels, i.e. the visible text. (This is the
-	 * default.)</li>
+	 * <li><b>label</b>=<i>labelPattern</i>: matches options based on their labels, i.e. the visible text. (This is the default.)</li>
 	 * <li><b>value</b>=<i>valuePattern</i>: matches options based on their values.</li>
 	 * <li><b>index</b>=<i>index</i>: matches an option based on its index (offset from zero).</li>
 	 * </ul>
 	 *
-	 * @param optionLocator
-	 *            option locator to be used for select action
+	 * @param optionLocator option locator to be used for select action
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean select(String optionLocator) {
@@ -737,20 +670,17 @@ public class SeleniumFixture {
 	 * | select | <i>optionLocator</i> | in | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Select an option from a drop-down using an option locator. Option locators provide different ways of specifying
-	 * options of an HTML Select element (e.g. for selecting a specific option, or for asserting that the selected
-	 * option satisfies a specification). There are several forms of Select Option Locator.
+	 * Select an option from a drop-down using an option locator.
+	 * Option locators provide different ways of specifying options of an HTML Select element (e.g. for selecting a specific option, or for asserting that the selected option satisfies a
+	 * specification). There are several forms of Select Option Locator.
 	 * <ul>
-	 * <li><b>label</b>=<i>labelPattern</i>: matches options based on their labels, i.e. the visible text. (This is the
-	 * default.)</li>
+	 * <li><b>label</b>=<i>labelPattern</i>: matches options based on their labels, i.e. the visible text. (This is the default.)</li>
 	 * <li><b>value</b>=<i>valuePattern</i>: matches options based on their values.</li>
 	 * <li><b>index</b>=<i>index</i>: matches an option based on its index (offset from zero).</li>
 	 * </ul>
 	 *
-	 * @param optionLocator
-	 *            option locator to be used for select action
-	 * @param locator
-	 *            an element locator
+	 * @param optionLocator option locator to be used for select action
+	 * @param locator an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean selectIn(String optionLocator, String locator) {
@@ -763,17 +693,14 @@ public class SeleniumFixture {
 	 * | check | selected | <i>optionType</i> |
 	 * </code>
 	 * </p>
-	 * Gets option data for selected option for the currently focused select element. Can return three types of
-	 * information depending of <i>optionType</i>:
+	 * Gets option data for selected option for the currently focused select element. Can return three types of information depending of <i>optionType</i>:
 	 * <ul>
 	 * <li><b>label</b>: Gets option label (visible text) for selected option in the specified select element.</li>
 	 * <li><b>value</b>: Gets option value (value attribute) for selected option in the specified select element.</li>
-	 * <li><b>index</b>: Gets option index (option number, starting at 0) for selected option in the specified select
-	 * element.</li>
+	 * <li><b>index</b>: Gets option index (option number, starting at 0) for selected option in the specified select element.</li>
 	 * </ul>
 	 *
-	 * @param optionType
-	 *            can be label, value or index
+	 * @param optionType can be label, value or index
 	 * @return the appropriate information associated with the select
 	 */
 	public String selected(String optionType) {
@@ -786,19 +713,15 @@ public class SeleniumFixture {
 	 * | check | selected | <i>optionType</i> | in | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Gets option data for selected option in the specified select element. Can return three types of information
-	 * depending of <i>optionType</i>:
+	 * Gets option data for selected option in the specified select element. Can return three types of information depending of <i>optionType</i>:
 	 * <ul>
 	 * <li><b>label</b>: Gets option label (visible text) for selected option in the specified select element.</li>
 	 * <li><b>value</b>: Gets option value (value attribute) for selected option in the specified select element.</li>
-	 * <li><b>index</b>: Gets option index (option number, starting at 0) for selected option in the specified select
-	 * element.</li>
+	 * <li><b>index</b>: Gets option index (option number, starting at 0) for selected option in the specified select element.</li>
 	 * </ul>
 	 *
-	 * @param optionType
-	 *            can be label, value or index
-	 * @param locator
-	 *            an element locator
+	 * @param optionType can be label, value or index
+	 * @param locator an element locator
 	 * @return the appropriate information associated with the select
 	 */
 	public String selectedIn(String optionType, String locator) {
@@ -811,11 +734,10 @@ public class SeleniumFixture {
 	 * | check | value | <i>locator</i> | <i>expectedValue</i> |
 	 * </code>
 	 * </p>
-	 * Gets the (whitespace-trimmed) value of an input field (or anything else with a value parameter). For
-	 * checkbox/radio elements, the value will be "on" or "off" depending on whether the element is checked or not.
+	 * Gets the (whitespace-trimmed) value of an input field (or anything else with a value parameter). For checkbox/radio elements, the value will be "on" or "off" depending on whether the element is
+	 * checked or not.
 	 *
-	 * @param locator
-	 *            an element locator
+	 * @param locator an element locator
 	 * @return value associated with the locator
 	 */
 	public String value(String locator) {
@@ -835,19 +757,15 @@ public class SeleniumFixture {
 	 * | check | <i>attribute</i> | <i>attributeName</i> | in | <i>locator</i> |  <i>expectedValue</i> |
 	 * </code>
 	 * </p>
-	 * Gets the value of an element attribute. The value of the attribute may differ across browsers (this is the case
-	 * for the "style" attribute, for example).
+	 * Gets the value of an element attribute. The value of the attribute may differ across browsers (this is the case for the "style" attribute, for example).
 	 *
-	 * @param attributeName
-	 *            the name of the attribute to retrieve the value from
-	 * @param locator
-	 *            an element locator
+	 * @param attributeName the name of the attribute to retrieve the value from
+	 * @param locator an element locator
 	 * @return value associated with the locator
 	 */
 	public String attributeIn(String attributeName, String locator) {
 		Pair<String, String> attributeAndLocatorWithValue = this.fitnesseMarkup.swapValueToCheck(attributeName, locator);
-		return SeleniumFixture.WEB_DRIVER.getWhenAvailable(attributeAndLocatorWithValue.getRight(), (driver, parsedLocator) -> driver
-			.findElement(parsedLocator.getBy()).getAttribute(this.fitnesseMarkup.clean(attributeAndLocatorWithValue.getLeft())));
+		return SeleniumFixture.WEB_DRIVER.getWhenAvailable(attributeAndLocatorWithValue.getRight(), (driver, parsedLocator) -> driver.findElement(parsedLocator.getBy()).getAttribute(this.fitnesseMarkup.clean(attributeAndLocatorWithValue.getLeft())));
 	}
 
 	/**
@@ -856,9 +774,9 @@ public class SeleniumFixture {
 	 * | check | text | <i>locator</i> | <i>expectedValue</i> |
 	 * </code>
 	 * </p>
-	 * Gets the text of the current focused element. This works for any element that contains text. This command uses
-	 * either the textContent (Mozilla-like browsers) or the innerText (IE-like browsers) of the element, which is the
-	 * rendered text shown to the user.
+	 * Gets the text of the current focused element. This works for any element that contains text. This command uses either the textContent (Mozilla-like browsers) or the innerText (IE-like browsers)
+	 * of the element,
+	 * which is the rendered text shown to the user.
 	 * <p>
 	 * If a dialog box is being presented on the page (such as an alert dialog), this action will return the dialog text
 	 * </p>
@@ -875,12 +793,10 @@ public class SeleniumFixture {
 	 * | check | text | <i>locator</i> | <i>expectedValue</i> |
 	 * </code>
 	 * </p>
-	 * Gets the text of an element. This works for any element that contains text. This command uses either the
-	 * textContent (Mozilla-like browsers) or the innerText (IE-like browsers) of the element, which is the rendered
-	 * text shown to the user.
+	 * Gets the text of an element. This works for any element that contains text. This command uses either the textContent (Mozilla-like browsers) or the innerText (IE-like browsers) of the element,
+	 * which is the rendered text shown to the user.
 	 *
-	 * @param locator
-	 *            an element locator
+	 * @param locator an element locator
 	 * @return text associated with the locator
 	 */
 	public String text(String locator) {
@@ -900,8 +816,7 @@ public class SeleniumFixture {
 	 * Takes screenshot from current browser state and returns to be previewed in test result page.
 	 *
 	 * @return screenshot saved file absolute path
-	 * @throws IOException
-	 *             if something goes wrong while manipulating screenshot file
+	 * @throws IOException if something goes wrong while manipulating screenshot file
 	 */
 	public String screenshot() throws IOException {
 		return SeleniumFixture.WEB_DRIVER.getWhenAvailable(StringUtils.EMPTY, (driver, parsedLocator) -> {
@@ -945,15 +860,13 @@ public class SeleniumFixture {
 	 * | reject | present | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Verifies that the specified element is somewhere on the page (or not). There's a few differences from SeleniumIDE
-	 * version, this method also supports attributes, if the selector is something like
-	 * "id=&lt;id&gt;@&lt;attributeName&gt;", this method will return true if the attribute exists on the element with
-	 * any value.
+	 * Verifies that the specified element is somewhere on the page (or not).
+	 * There's a few differences from SeleniumIDE version, this method also supports attributes, if the selector is something like "id=&lt;id&gt;@&lt;attributeName&gt;",
+	 * this method will return true if the attribute exists on the element with any value.
 	 * <p>
 	 * <b>Note</b>: Wait behavior won't work properly without selenium table
 	 *
-	 * @param locator
-	 *            an element locator
+	 * @param locator an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean present(String locator) {
@@ -975,14 +888,12 @@ public class SeleniumFixture {
 	 * | $result= | run script | <i>code</i> |
 	 * </code>
 	 * </p>
-	 * Creates a new "script" tag in the body of the current test window, and adds the specified text into the body of
-	 * the command. Scripts run in this way can often be debugged more easily than scripts executed using Selenium's
-	 * "getEval" command. Beware that JS exceptions thrown in these script tags aren't managed by Selenium, so you
-	 * should probably wrap your script in try/catch blocks if there is any chance that the script will throw an
-	 * exception.
+	 * Creates a new "script" tag in the body of the current test window, and adds the specified text into the body of the command.
+	 * Scripts run in this way can often be debugged more easily than scripts executed using Selenium's "getEval" command.
+	 * Beware that JS exceptions thrown in these script tags aren't managed by Selenium, so you should probably wrap your script in try/catch blocks if there is any chance that the script will throw
+	 * an exception.
 	 *
-	 * @param script
-	 *            the JavaScript snippet to run
+	 * @param script the JavaScript snippet to run
 	 * @return of the javascript snippet that ran
 	 */
 	public String runScript(String script) {
@@ -1006,13 +917,11 @@ public class SeleniumFixture {
 	 * </code>
 	 * </p>
 	 *
-	 * @param shouldStop
-	 *            If <b>true</b> or <b>on</b>, the test will stop if a failure occurs in any action
+	 * @param shouldStop If <b>true</b> or <b>on</b>, the test will stop if a failure occurs in any action
 	 * @return previous configuration value. If enabled will return <b>on</b>, <b>off</b> otherwise.
 	 */
 	public String stopTestOnFirstFailure(String shouldStop) {
-		return acceptConfigReturnPrevious(shouldStop, SeleniumFixture.WEB_DRIVER.getStopTestOnFirstFailure(),
-			SeleniumFixture.WEB_DRIVER::setStopTestOnFirstFailure);
+		return acceptConfigReturnPrevious(shouldStop, SeleniumFixture.WEB_DRIVER.getStopTestOnFirstFailure(), SeleniumFixture.WEB_DRIVER::setStopTestOnFirstFailure);
 	}
 
 	/**
@@ -1021,15 +930,11 @@ public class SeleniumFixture {
 	 * | set take screenshot on failure | true |
 	 * </code>
 	 * </p>
-	 * 
-	 * @param shouldTake
-	 *            If <b>true</b> or <b>on</b>, a screenshot will be appended (if possible) to a failed selenium
-	 *            operation.
+	 * @param shouldTake If <b>true</b> or <b>on</b>, a screenshot will be appended (if possible) to a failed selenium operation.
 	 * @return previous configuration value. If enabled will return <b>on</b>, <b>off</b> otherwise.
 	 */
 	public String setTakeScreenshotOnFailure(String shouldTake) {
-		return acceptConfigReturnPrevious(shouldTake, SeleniumFixture.WEB_DRIVER.getTakeScreenshotOnFailure(),
-			SeleniumFixture.WEB_DRIVER::setTakeScreenshotOnFailure);
+		return acceptConfigReturnPrevious(shouldTake, SeleniumFixture.WEB_DRIVER.getTakeScreenshotOnFailure(), SeleniumFixture.WEB_DRIVER::setTakeScreenshotOnFailure);
 	}
 
 	public String setDryRun(String enableDryRun) {
@@ -1067,17 +972,14 @@ public class SeleniumFixture {
 	 * </p>
 	 * Checks if a file exists in the local filesystem. Will respect wait timeout until file is available
 	 * <p>
-	 * <b>Important:</b> If you're using remote browsers such as Selenium Grid or SauceLabs, this action probably won't
-	 * be useful, unless you have access to the node's remote file system.
+	 * <b>Important:</b> If you're using remote browsers such as Selenium Grid or SauceLabs, this action probably won't be useful, unless you have access to the node's remote file system.
 	 * </p>
 	 *
-	 * @param file
-	 *            Path of the file to check if exists
+	 * @param file Path of the file to check if exists
 	 * @return if the informed file exists on the filesystem
 	 */
 	public boolean fileExists(String file) {
-		return Boolean.valueOf(SeleniumFixture.WEB_DRIVER.getWhenAvailable(file,
-			(driver, parsedLocator) -> Boolean.toString(this.fitnesseMarkup.cleanFile(parsedLocator.getOriginalSelector()).exists())));
+		return Boolean.valueOf(SeleniumFixture.WEB_DRIVER.getWhenAvailable(file, (driver, parsedLocator) -> Boolean.toString(this.fitnesseMarkup.cleanFile(parsedLocator.getOriginalSelector()).exists())));
 	}
 
 	/**

--- a/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
+++ b/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
@@ -56,7 +56,8 @@ public class SeleniumFixture {
 	private static final String BLANK_PAGE = "about:blank";
 
 	/**
-	 * Instance that wraps {@link WebDriver} providing utility methods to manipulate elements and such. Attribute is static to keep state between table invocations
+	 * Instance that wraps {@link WebDriver} providing utility methods to manipulate elements and such. Attribute is
+	 * static to keep state between table invocations
 	 */
 	private static WebDriverHelper WEB_DRIVER = new WebDriverHelper();
 
@@ -86,9 +87,12 @@ public class SeleniumFixture {
 	 * Registers the DRIVER to further execute selenium commands
 	 *
 	 * @see #startBrowserWith(String, String)
-	 * @param browser The browser to be used
-	 * @throws ReflectiveOperationException if remote driver class cannot be instantiated
-	 * @throws IOException if IO error occurs if invalid URL is used when connecting to remote drivers
+	 * @param browser
+	 *            The browser to be used
+	 * @throws ReflectiveOperationException
+	 *             if remote driver class cannot be instantiated
+	 * @throws IOException
+	 *             if IO error occurs if invalid URL is used when connecting to remote drivers
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean startBrowser(String browser) throws ReflectiveOperationException, IOException {
@@ -101,16 +105,23 @@ public class SeleniumFixture {
 	 * | start browser | <i>browser</i> | with | <i>capabilities</i> |
 	 * </code>
 	 * </p>
-	 * Registers the DRIVER to further execute selenium commands. Capabilities should be informed in the following format:
+	 * Registers the DRIVER to further execute selenium commands. Capabilities should be informed in the following
+	 * format:
 	 * <p>
 	 * name='some test' platform='LINUX' version='xx'
 	 * </p>
-	 * This format was used instead of regular json format since FitNesse uses brackets for variables. Quotes between values must be used
+	 * This format was used instead of regular json format since FitNesse uses brackets for variables. Quotes between
+	 * values must be used
 	 *
-	 * @param browser The browser to be used
-	 * @param capabilities Usually used to configure remote driver, but some local driver also uses. For example: name='some test' platform='LINUX' version='xx'
-	 * @throws ReflectiveOperationException if remote driver class cannot be instantiated
-	 * @throws IOException if IO error occurs if invalid URL is used when connecting to remote drivers
+	 * @param browser
+	 *            The browser to be used
+	 * @param capabilities
+	 *            Usually used to configure remote driver, but some local driver also uses. For example: name='some
+	 *            test' platform='LINUX' version='xx'
+	 * @throws ReflectiveOperationException
+	 *             if remote driver class cannot be instantiated
+	 * @throws IOException
+	 *             if IO error occurs if invalid URL is used when connecting to remote drivers
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean startBrowserWith(String browser, String capabilities) throws ReflectiveOperationException, IOException {
@@ -123,17 +134,24 @@ public class SeleniumFixture {
 	 * | start browser | <i>browser</i> | with preferences | <i>browser preferences</i> |
 	 * </code>
 	 * </p>
-	 * Registers the DRIVER to further execute selenium commands. Preferences should be informed in the following format:
+	 * Registers the DRIVER to further execute selenium commands. Preferences should be informed in the following
+	 * format:
 	 * <p>
 	 * name='some test' platform='LINUX' version='xx'
 	 * </p>
-	 * This format was used instead of regular json format since FitNesse uses brackets for variables. Quotes between values must be used
+	 * This format was used instead of regular json format since FitNesse uses brackets for variables. Quotes between
+	 * values must be used
 	 *
-	 * @param browser The browser to be used
-	 * @param browserPreferences Allows profile configuration for some browser. At this moment supports Chrome and Firefox drivers (local and remote)
+	 * @param browser
+	 *            The browser to be used
+	 * @param browserPreferences
+	 *            Allows profile configuration for some browser. At this moment supports Chrome and Firefox drivers
+	 *            (local and remote)
 	 * @return result Boolean result indication of assertion/operation
-	 * @throws ReflectiveOperationException if remote driver class cannot be instantiated
-	 * @throws IOException if IO error occurs if invalid URL is used when connecting to remote drivers
+	 * @throws ReflectiveOperationException
+	 *             if remote driver class cannot be instantiated
+	 * @throws IOException
+	 *             if IO error occurs if invalid URL is used when connecting to remote drivers
 	 */
 	public boolean startBrowserWithPreferences(String browser, String browserPreferences) throws ReflectiveOperationException, IOException {
 		return startBrowserWithAndPreferences(browser, null, browserPreferences);
@@ -145,20 +163,30 @@ public class SeleniumFixture {
 	 * | start browser | <i>browser</i> | with | <i>capabilities</i> | and preferences | <i>browser preferences</i> |
 	 * </code>
 	 * </p>
-	 * Registers the DRIVER to further execute selenium commands. Capabilities as well as browser preferences should be informed in the following format:
+	 * Registers the DRIVER to further execute selenium commands. Capabilities as well as browser preferences should be
+	 * informed in the following format:
 	 * <p>
 	 * key1='value1' key2='value2' key3='value3'
 	 * </p>
-	 * This format was used instead of regular json format since FitNesse uses brackets for variables. Quotes between values must be used
+	 * This format was used instead of regular json format since FitNesse uses brackets for variables. Quotes between
+	 * values must be used
 	 *
-	 * @param browser The browser to be used
-	 * @param capabilities Usually used to configure remote driver, but some local driver also uses. For example: name='some test' platform='LINUX' version='xx'
-	 * @param browserPreferences Allows profile configuration for some browser. At this moment supports Chrome and Firefox drivers (local and remote)
+	 * @param browser
+	 *            The browser to be used
+	 * @param capabilities
+	 *            Usually used to configure remote driver, but some local driver also uses. For example: name='some
+	 *            test' platform='LINUX' version='xx'
+	 * @param browserPreferences
+	 *            Allows profile configuration for some browser. At this moment supports Chrome and Firefox drivers
+	 *            (local and remote)
 	 * @return result Boolean result indication of assertion/operation
-	 * @throws ReflectiveOperationException if remote driver class cannot be instantiated
-	 * @throws IOException if IO error occurs if invalid URL is used when connecting to remote drivers
+	 * @throws ReflectiveOperationException
+	 *             if remote driver class cannot be instantiated
+	 * @throws IOException
+	 *             if IO error occurs if invalid URL is used when connecting to remote drivers
 	 */
-	public boolean startBrowserWithAndPreferences(String browser, String capabilities, String browserPreferences) throws ReflectiveOperationException, IOException {
+	public boolean startBrowserWithAndPreferences(String browser, String capabilities, String browserPreferences)
+		throws ReflectiveOperationException, IOException {
 		SeleniumFixture.WEB_DRIVER.connect(browser, capabilities, browserPreferences);
 		return true;
 	}
@@ -171,7 +199,8 @@ public class SeleniumFixture {
 	 * </p>
 	 * Sets the time to wait while finding an element.
 	 *
-	 * @param timeoutInSeconds wait seconds to timeout
+	 * @param timeoutInSeconds
+	 *            wait seconds to timeout
 	 * @return previous timeout value
 	 */
 	public int setWaitTimeout(int timeoutInSeconds) {
@@ -187,7 +216,8 @@ public class SeleniumFixture {
 	 * </code>
 	 * </p>
 	 *
-	 * @return how much time the last command took to complete. Useful to ensure tests perfomance and such. Will be 0 if no commands were executed
+	 * @return how much time the last command took to complete. Useful to ensure tests perfomance and such. Will be 0 if
+	 *         no commands were executed
 	 */
 	public long lastCommandDuration() {
 		return SeleniumFixture.WEB_DRIVER.getLastActionDurationInSeconds();
@@ -201,7 +231,8 @@ public class SeleniumFixture {
 	 * </p>
 	 * Navigates to the the desired url
 	 *
-	 * @param url to navigate
+	 * @param url
+	 *            to navigate
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean open(String url) {
@@ -255,9 +286,11 @@ public class SeleniumFixture {
 	 * | check | current url | <i>url</i> | <i>url</i> |
 	 * </code>
 	 * </p>
-	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using selenium table, please ignore this action.
+	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using
+	 * selenium table, please ignore this action.
 	 *
-	 * @param expectedUrl that we'll wait for
+	 * @param expectedUrl
+	 *            that we'll wait for
 	 * @return the current page title
 	 */
 	public String currentUrl(String expectedUrl) {
@@ -279,10 +312,12 @@ public class SeleniumFixture {
 	 * | open window | <i>url</i> |
 	 * </code>
 	 * </p>
-	 * Opens a popup window with desired <i>url</i>. After opening the window, you'll need to select it using the selectWindow command.
+	 * Opens a popup window with desired <i>url</i>. After opening the window, you'll need to select it using the
+	 * selectWindow command.
 	 *
 	 * @see #selectWindow(String)
-	 * @param url to navigate
+	 * @param url
+	 *            to navigate
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean openWindow(String url) {
@@ -295,10 +330,11 @@ public class SeleniumFixture {
 	 * | select window | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Selects a popup window using a window locator; once a popup window has been selected, all commands go to that window.
-	 * Currently supports window search by nameOrHandle, title and current url
+	 * Selects a popup window using a window locator; once a popup window has been selected, all commands go to that
+	 * window. Currently supports window search by nameOrHandle, title and current url
 	 *
-	 * @param locator an element locator
+	 * @param locator
+	 *            an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean selectWindow(String locator) {
@@ -307,7 +343,8 @@ public class SeleniumFixture {
 			String currentWindow = driver.getWindowHandle();
 			for (String windowId : driver.getWindowHandles()) {
 				WebDriver window = driver.switchTo().window(windowId);
-				if (this.fitnesseMarkup.compare(parsedWindowLocator, windowId) || this.fitnesseMarkup.compare(parsedWindowLocator, window.getTitle()) || this.fitnesseMarkup.compare(parsedWindowLocator, window.getCurrentUrl())) {
+				if (this.fitnesseMarkup.compare(parsedWindowLocator, windowId) || this.fitnesseMarkup.compare(parsedWindowLocator, window.getTitle())
+					|| this.fitnesseMarkup.compare(parsedWindowLocator, window.getCurrentUrl())) {
 					return;
 				}
 			}
@@ -325,11 +362,13 @@ public class SeleniumFixture {
 	 * | select frame | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Selects a frame within the current window. (You may invoke this command multiple times to select nested frames.) To select the parent frame, use "relative=parent" as a locator; to select the
-	 * top frame, use "relative=top". You can also select a frame by its 0-based index number; select the first frame with "index=0", or the third frame with "index=2".
-	 * Note that you can use all element locators such as <b>id</b>, <b>css</b>, <b>xpath</b> and so on
+	 * Selects a frame within the current window. (You may invoke this command multiple times to select nested frames.)
+	 * To select the parent frame, use "relative=parent" as a locator; to select the top frame, use "relative=top". You
+	 * can also select a frame by its 0-based index number; select the first frame with "index=0", or the third frame
+	 * with "index=2". Note that you can use all element locators such as <b>id</b>, <b>css</b>, <b>xpath</b> and so on
 	 *
-	 * @param locator an element locator
+	 * @param locator
+	 *            an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean selectFrame(String locator) {
@@ -356,9 +395,11 @@ public class SeleniumFixture {
 	 * | check | current window | <i>windowHandle</i> | <i>windowHandle</i> |
 	 * </code>
 	 * </p>
-	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using selenium table, please ignore this action.
+	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using
+	 * selenium table, please ignore this action.
 	 *
-	 * @param expectedWindowHandle that we'll wait for
+	 * @param expectedWindowHandle
+	 *            that we'll wait for
 	 * @return the current page title
 	 */
 	public String currentWindow(String expectedWindowHandle) {
@@ -389,11 +430,14 @@ public class SeleniumFixture {
 	 * | set window size | <i>[width]x[height]</i> |
 	 * </code>
 	 * </p>
-	 * Set the size of the current window. This will change the outer window dimension, not just the view port, synonymous to window.resizeTo() in JS.
+	 * Set the size of the current window. This will change the outer window dimension, not just the view port,
+	 * synonymous to window.resizeTo() in JS.
 	 *
-	 * @param widthAndHeight windows size, in [width]x[height] format
+	 * @param widthAndHeight
+	 *            windows size, in [width]x[height] format
 	 * @return result Boolean result indication of assertion/operation
-	 * @throws IllegalArgumentException if widthAndHeight is malformed
+	 * @throws IllegalArgumentException
+	 *             if widthAndHeight is malformed
 	 */
 	public boolean setWindowSize(String widthAndHeight) {
 		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(StringUtils.EMPTY, (driver, parsedLocator) -> {
@@ -421,9 +465,11 @@ public class SeleniumFixture {
 	 * | window size |
 	 * </code>
 	 * </p>
-	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using selenium table, please ignore this action.
+	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using
+	 * selenium table, please ignore this action.
 	 *
-	 * @param expectedWindowSize Expected window size
+	 * @param expectedWindowSize
+	 *            Expected window size
 	 * @return windows size, in [width]x[height] format
 	 */
 	public String windowSize(String expectedWindowSize) {
@@ -453,9 +499,11 @@ public class SeleniumFixture {
 	 * | check | title | <i>title</i> | <i>title</i> |
 	 * </code>
 	 * </p>
-	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using selenium table, please ignore this action.
+	 * To be used along slim check action. Will respect {@link #setWaitTimeout(int)} before triggering failure. If using
+	 * selenium table, please ignore this action.
 	 *
-	 * @param expectedTitle that we'll wait for
+	 * @param expectedTitle
+	 *            that we'll wait for
 	 * @return the current page title
 	 */
 	public String title(String expectedTitle) {
@@ -504,10 +552,12 @@ public class SeleniumFixture {
 	 * | type | <i>value</i> |
 	 * </code>
 	 * </p>
-	 * Sets the value of the current focused input field, as though you typed it in.
-	 * Can also be used to set the value of combo boxes, check boxes, etc. In these cases, value should be the value of the option selected, not the visible text.
+	 * Sets the value of the current focused input field, as though you typed it in. Can also be used to set the value
+	 * of combo boxes, check boxes, etc. In these cases, value should be the value of the option selected, not the
+	 * visible text.
 	 *
-	 * @param value the value to typeIn
+	 * @param value
+	 *            the value to typeIn
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean type(String value) {
@@ -520,11 +570,13 @@ public class SeleniumFixture {
 	 * | type | <i>value</i> | in | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Sets the value of an input field, as though you typed it in.
-	 * Can also be used to set the value of combo boxes, check boxes, etc. In these cases, value should be the value of the option selected, not the visible text.
+	 * Sets the value of an input field, as though you typed it in. Can also be used to set the value of combo boxes,
+	 * check boxes, etc. In these cases, value should be the value of the option selected, not the visible text.
 	 *
-	 * @param value the value to typeIn
-	 * @param locator an element locator
+	 * @param value
+	 *            the value to typeIn
+	 * @param locator
+	 *            an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean typeIn(String value, String locator) {
@@ -537,13 +589,17 @@ public class SeleniumFixture {
 	 * | send keys | <i>value</i> |
 	 * </code>
 	 * </p>
-	 * Simulates keystroke events on the current focused element, as though you typed the value key-by-key.
-	 * This simulates a real user typing every character in the specified string; it is also bound by the limitations of a real user, like not being able to type into a invisible or read only
-	 * elements. This is useful for dynamic UI widgets (like auto-completing combo boxes) that require explicit key events.
-	 * Unlike the simple "type" command, which forces the specified value into the page directly, this command will not replace the existing content. If you want to replace the existing contents, you
-	 * need to use the simple "type" command to set the value of the field to empty string to clear the field and then the "sendKeys" command to send the keystroke for what you want to type.
+	 * Simulates keystroke events on the current focused element, as though you typed the value key-by-key. This
+	 * simulates a real user typing every character in the specified string; it is also bound by the limitations of a
+	 * real user, like not being able to type into a invisible or read only elements. This is useful for dynamic UI
+	 * widgets (like auto-completing combo boxes) that require explicit key events. Unlike the simple "type" command,
+	 * which forces the specified value into the page directly, this command will not replace the existing content. If
+	 * you want to replace the existing contents, you need to use the simple "type" command to set the value of the
+	 * field to empty string to clear the field and then the "sendKeys" command to send the keystroke for what you want
+	 * to type.
 	 *
-	 * @param value the value to typeIn
+	 * @param value
+	 *            the value to typeIn
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean sendKeys(String value) {
@@ -556,14 +612,18 @@ public class SeleniumFixture {
 	 * | send keys | <i>value</i> | in | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Simulates keystroke events on the specified element, as though you typed the value key-by-key.
-	 * This simulates a real user typing every character in the specified string; it is also bound by the limitations of a real user, like not being able to type into a invisible or read only
-	 * elements. This is useful for dynamic UI widgets (like auto-completing combo boxes) that require explicit key events.
-	 * Unlike the simple "type" command, which forces the specified value into the page directly, this command will not replace the existing content. If you want to replace the existing contents, you
-	 * need to use the simple "type" command to set the value of the field to empty string to clear the field and then the "sendKeys" command to send the keystroke for what you want to type.
+	 * Simulates keystroke events on the specified element, as though you typed the value key-by-key. This simulates a
+	 * real user typing every character in the specified string; it is also bound by the limitations of a real user,
+	 * like not being able to type into a invisible or read only elements. This is useful for dynamic UI widgets (like
+	 * auto-completing combo boxes) that require explicit key events. Unlike the simple "type" command, which forces the
+	 * specified value into the page directly, this command will not replace the existing content. If you want to
+	 * replace the existing contents, you need to use the simple "type" command to set the value of the field to empty
+	 * string to clear the field and then the "sendKeys" command to send the keystroke for what you want to type.
 	 *
-	 * @param value the value to typeIn
-	 * @param locator an element locator
+	 * @param value
+	 *            the value to typeIn
+	 * @param locator
+	 *            an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean sendKeysIn(String value, String locator) {
@@ -585,12 +645,15 @@ public class SeleniumFixture {
 	}
 
 	/**
-	 * When send keys is being executed in a input file=type {@link LocalFileDetector} must be configured for remote drivers. Additionally,
-	 * the file path is expanded to be absolute
+	 * When send keys is being executed in a input file=type {@link LocalFileDetector} must be configured for remote
+	 * drivers. Additionally, the file path is expanded to be absolute
 	 *
-	 * @param driver used to run commands
-	 * @param element receiving keys
-	 * @param value to be set to input file type
+	 * @param driver
+	 *            used to run commands
+	 * @param element
+	 *            receiving keys
+	 * @param value
+	 *            to be set to input file type
 	 * @return value expanded to absolute path if for input file type.
 	 */
 	private String cleanValueToSend(WebDriver driver, WebElement element, String value) {
@@ -624,9 +687,11 @@ public class SeleniumFixture {
 	 * | click | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Clicks on a link, button, checkbox or radio button. If the click action causes a new page to load (like a link usually does), call waitForPageToLoad.
+	 * Clicks on a link, button, checkbox or radio button. If the click action causes a new page to load (like a link
+	 * usually does), call waitForPageToLoad.
 	 *
-	 * @param locator an element locator
+	 * @param locator
+	 *            an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean click(String locator) {
@@ -648,16 +713,18 @@ public class SeleniumFixture {
 	 * | select | <i>optionLocator</i> |
 	 * </code>
 	 * </p>
-	 * Select an option from the currently focused drop-down using an option locator.
-	 * Option locators provide different ways of specifying options of an HTML Select element (e.g. for selecting a specific option, or for asserting that the selected option satisfies a
-	 * specification). There are several forms of Select Option Locator.
+	 * Select an option from the currently focused drop-down using an option locator. Option locators provide different
+	 * ways of specifying options of an HTML Select element (e.g. for selecting a specific option, or for asserting that
+	 * the selected option satisfies a specification). There are several forms of Select Option Locator.
 	 * <ul>
-	 * <li><b>label</b>=<i>labelPattern</i>: matches options based on their labels, i.e. the visible text. (This is the default.)</li>
+	 * <li><b>label</b>=<i>labelPattern</i>: matches options based on their labels, i.e. the visible text. (This is the
+	 * default.)</li>
 	 * <li><b>value</b>=<i>valuePattern</i>: matches options based on their values.</li>
 	 * <li><b>index</b>=<i>index</i>: matches an option based on its index (offset from zero).</li>
 	 * </ul>
 	 *
-	 * @param optionLocator option locator to be used for select action
+	 * @param optionLocator
+	 *            option locator to be used for select action
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean select(String optionLocator) {
@@ -670,17 +737,20 @@ public class SeleniumFixture {
 	 * | select | <i>optionLocator</i> | in | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Select an option from a drop-down using an option locator.
-	 * Option locators provide different ways of specifying options of an HTML Select element (e.g. for selecting a specific option, or for asserting that the selected option satisfies a
-	 * specification). There are several forms of Select Option Locator.
+	 * Select an option from a drop-down using an option locator. Option locators provide different ways of specifying
+	 * options of an HTML Select element (e.g. for selecting a specific option, or for asserting that the selected
+	 * option satisfies a specification). There are several forms of Select Option Locator.
 	 * <ul>
-	 * <li><b>label</b>=<i>labelPattern</i>: matches options based on their labels, i.e. the visible text. (This is the default.)</li>
+	 * <li><b>label</b>=<i>labelPattern</i>: matches options based on their labels, i.e. the visible text. (This is the
+	 * default.)</li>
 	 * <li><b>value</b>=<i>valuePattern</i>: matches options based on their values.</li>
 	 * <li><b>index</b>=<i>index</i>: matches an option based on its index (offset from zero).</li>
 	 * </ul>
 	 *
-	 * @param optionLocator option locator to be used for select action
-	 * @param locator an element locator
+	 * @param optionLocator
+	 *            option locator to be used for select action
+	 * @param locator
+	 *            an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean selectIn(String optionLocator, String locator) {
@@ -693,14 +763,17 @@ public class SeleniumFixture {
 	 * | check | selected | <i>optionType</i> |
 	 * </code>
 	 * </p>
-	 * Gets option data for selected option for the currently focused select element. Can return three types of information depending of <i>optionType</i>:
+	 * Gets option data for selected option for the currently focused select element. Can return three types of
+	 * information depending of <i>optionType</i>:
 	 * <ul>
 	 * <li><b>label</b>: Gets option label (visible text) for selected option in the specified select element.</li>
 	 * <li><b>value</b>: Gets option value (value attribute) for selected option in the specified select element.</li>
-	 * <li><b>index</b>: Gets option index (option number, starting at 0) for selected option in the specified select element.</li>
+	 * <li><b>index</b>: Gets option index (option number, starting at 0) for selected option in the specified select
+	 * element.</li>
 	 * </ul>
 	 *
-	 * @param optionType can be label, value or index
+	 * @param optionType
+	 *            can be label, value or index
 	 * @return the appropriate information associated with the select
 	 */
 	public String selected(String optionType) {
@@ -713,15 +786,19 @@ public class SeleniumFixture {
 	 * | check | selected | <i>optionType</i> | in | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Gets option data for selected option in the specified select element. Can return three types of information depending of <i>optionType</i>:
+	 * Gets option data for selected option in the specified select element. Can return three types of information
+	 * depending of <i>optionType</i>:
 	 * <ul>
 	 * <li><b>label</b>: Gets option label (visible text) for selected option in the specified select element.</li>
 	 * <li><b>value</b>: Gets option value (value attribute) for selected option in the specified select element.</li>
-	 * <li><b>index</b>: Gets option index (option number, starting at 0) for selected option in the specified select element.</li>
+	 * <li><b>index</b>: Gets option index (option number, starting at 0) for selected option in the specified select
+	 * element.</li>
 	 * </ul>
 	 *
-	 * @param optionType can be label, value or index
-	 * @param locator an element locator
+	 * @param optionType
+	 *            can be label, value or index
+	 * @param locator
+	 *            an element locator
 	 * @return the appropriate information associated with the select
 	 */
 	public String selectedIn(String optionType, String locator) {
@@ -734,10 +811,11 @@ public class SeleniumFixture {
 	 * | check | value | <i>locator</i> | <i>expectedValue</i> |
 	 * </code>
 	 * </p>
-	 * Gets the (whitespace-trimmed) value of an input field (or anything else with a value parameter). For checkbox/radio elements, the value will be "on" or "off" depending on whether the element is
-	 * checked or not.
+	 * Gets the (whitespace-trimmed) value of an input field (or anything else with a value parameter). For
+	 * checkbox/radio elements, the value will be "on" or "off" depending on whether the element is checked or not.
 	 *
-	 * @param locator an element locator
+	 * @param locator
+	 *            an element locator
 	 * @return value associated with the locator
 	 */
 	public String value(String locator) {
@@ -757,15 +835,19 @@ public class SeleniumFixture {
 	 * | check | <i>attribute</i> | <i>attributeName</i> | in | <i>locator</i> |  <i>expectedValue</i> |
 	 * </code>
 	 * </p>
-	 * Gets the value of an element attribute. The value of the attribute may differ across browsers (this is the case for the "style" attribute, for example).
+	 * Gets the value of an element attribute. The value of the attribute may differ across browsers (this is the case
+	 * for the "style" attribute, for example).
 	 *
-	 * @param attributeName the name of the attribute to retrieve the value from
-	 * @param locator an element locator
+	 * @param attributeName
+	 *            the name of the attribute to retrieve the value from
+	 * @param locator
+	 *            an element locator
 	 * @return value associated with the locator
 	 */
 	public String attributeIn(String attributeName, String locator) {
 		Pair<String, String> attributeAndLocatorWithValue = this.fitnesseMarkup.swapValueToCheck(attributeName, locator);
-		return SeleniumFixture.WEB_DRIVER.getWhenAvailable(attributeAndLocatorWithValue.getRight(), (driver, parsedLocator) -> driver.findElement(parsedLocator.getBy()).getAttribute(this.fitnesseMarkup.clean(attributeAndLocatorWithValue.getLeft())));
+		return SeleniumFixture.WEB_DRIVER.getWhenAvailable(attributeAndLocatorWithValue.getRight(), (driver, parsedLocator) -> driver
+			.findElement(parsedLocator.getBy()).getAttribute(this.fitnesseMarkup.clean(attributeAndLocatorWithValue.getLeft())));
 	}
 
 	/**
@@ -774,9 +856,9 @@ public class SeleniumFixture {
 	 * | check | text | <i>locator</i> | <i>expectedValue</i> |
 	 * </code>
 	 * </p>
-	 * Gets the text of the current focused element. This works for any element that contains text. This command uses either the textContent (Mozilla-like browsers) or the innerText (IE-like browsers)
-	 * of the element,
-	 * which is the rendered text shown to the user.
+	 * Gets the text of the current focused element. This works for any element that contains text. This command uses
+	 * either the textContent (Mozilla-like browsers) or the innerText (IE-like browsers) of the element, which is the
+	 * rendered text shown to the user.
 	 * <p>
 	 * If a dialog box is being presented on the page (such as an alert dialog), this action will return the dialog text
 	 * </p>
@@ -793,10 +875,12 @@ public class SeleniumFixture {
 	 * | check | text | <i>locator</i> | <i>expectedValue</i> |
 	 * </code>
 	 * </p>
-	 * Gets the text of an element. This works for any element that contains text. This command uses either the textContent (Mozilla-like browsers) or the innerText (IE-like browsers) of the element,
-	 * which is the rendered text shown to the user.
+	 * Gets the text of an element. This works for any element that contains text. This command uses either the
+	 * textContent (Mozilla-like browsers) or the innerText (IE-like browsers) of the element, which is the rendered
+	 * text shown to the user.
 	 *
-	 * @param locator an element locator
+	 * @param locator
+	 *            an element locator
 	 * @return text associated with the locator
 	 */
 	public String text(String locator) {
@@ -816,12 +900,35 @@ public class SeleniumFixture {
 	 * Takes screenshot from current browser state and returns to be previewed in test result page.
 	 *
 	 * @return screenshot saved file absolute path
-	 * @throws IOException if something goes wrong while manipulating screenshot file
+	 * @throws IOException
+	 *             if something goes wrong while manipulating screenshot file
 	 */
 	public String screenshot() throws IOException {
 		return SeleniumFixture.WEB_DRIVER.getWhenAvailable(StringUtils.EMPTY, (driver, parsedLocator) -> {
 			if (driver instanceof TakesScreenshot) {
 				return this.fitnesseMarkup.imgLink(((TakesScreenshot) driver).getScreenshotAs(OutputType.BASE64));
+			}
+			return null;
+		});
+	}
+
+	/**
+	 * <p>
+	 * <code>
+	 * | show | screenshot of | <i>locator</i> |
+	 * </code>
+	 * </p>
+	 * Takes screenshot of the selected element and returns to be previewed in test result page.
+	 *
+	 * @return screenshot saved file absolute path
+	 * @throws IOException
+	 *             if something goes wrong while manipulating screenshot file
+	 */
+	public String screenshotOf(String locator) throws IOException {
+		return SeleniumFixture.WEB_DRIVER.getWhenAvailable(locator, (driver, parsedLocator) -> {
+			WebElement element = driver.findElement(parsedLocator.getBy());
+			if (element instanceof TakesScreenshot) {
+				return this.fitnesseMarkup.imgLink(((TakesScreenshot) element).getScreenshotAs(OutputType.BASE64));
 			}
 			return null;
 		});
@@ -838,13 +945,15 @@ public class SeleniumFixture {
 	 * | reject | present | <i>locator</i> |
 	 * </code>
 	 * </p>
-	 * Verifies that the specified element is somewhere on the page (or not).
-	 * There's a few differences from SeleniumIDE version, this method also supports attributes, if the selector is something like "id=&lt;id&gt;@&lt;attributeName&gt;",
-	 * this method will return true if the attribute exists on the element with any value.
+	 * Verifies that the specified element is somewhere on the page (or not). There's a few differences from SeleniumIDE
+	 * version, this method also supports attributes, if the selector is something like
+	 * "id=&lt;id&gt;@&lt;attributeName&gt;", this method will return true if the attribute exists on the element with
+	 * any value.
 	 * <p>
 	 * <b>Note</b>: Wait behavior won't work properly without selenium table
 	 *
-	 * @param locator an element locator
+	 * @param locator
+	 *            an element locator
 	 * @return result Boolean result indication of assertion/operation
 	 */
 	public boolean present(String locator) {
@@ -866,12 +975,14 @@ public class SeleniumFixture {
 	 * | $result= | run script | <i>code</i> |
 	 * </code>
 	 * </p>
-	 * Creates a new "script" tag in the body of the current test window, and adds the specified text into the body of the command.
-	 * Scripts run in this way can often be debugged more easily than scripts executed using Selenium's "getEval" command.
-	 * Beware that JS exceptions thrown in these script tags aren't managed by Selenium, so you should probably wrap your script in try/catch blocks if there is any chance that the script will throw
-	 * an exception.
+	 * Creates a new "script" tag in the body of the current test window, and adds the specified text into the body of
+	 * the command. Scripts run in this way can often be debugged more easily than scripts executed using Selenium's
+	 * "getEval" command. Beware that JS exceptions thrown in these script tags aren't managed by Selenium, so you
+	 * should probably wrap your script in try/catch blocks if there is any chance that the script will throw an
+	 * exception.
 	 *
-	 * @param script the JavaScript snippet to run
+	 * @param script
+	 *            the JavaScript snippet to run
 	 * @return of the javascript snippet that ran
 	 */
 	public String runScript(String script) {
@@ -895,11 +1006,13 @@ public class SeleniumFixture {
 	 * </code>
 	 * </p>
 	 *
-	 * @param shouldStop If <b>true</b> or <b>on</b>, the test will stop if a failure occurs in any action
+	 * @param shouldStop
+	 *            If <b>true</b> or <b>on</b>, the test will stop if a failure occurs in any action
 	 * @return previous configuration value. If enabled will return <b>on</b>, <b>off</b> otherwise.
 	 */
 	public String stopTestOnFirstFailure(String shouldStop) {
-		return acceptConfigReturnPrevious(shouldStop, SeleniumFixture.WEB_DRIVER.getStopTestOnFirstFailure(), SeleniumFixture.WEB_DRIVER::setStopTestOnFirstFailure);
+		return acceptConfigReturnPrevious(shouldStop, SeleniumFixture.WEB_DRIVER.getStopTestOnFirstFailure(),
+			SeleniumFixture.WEB_DRIVER::setStopTestOnFirstFailure);
 	}
 
 	/**
@@ -908,11 +1021,15 @@ public class SeleniumFixture {
 	 * | set take screenshot on failure | true |
 	 * </code>
 	 * </p>
-	 * @param shouldTake If <b>true</b> or <b>on</b>, a screenshot will be appended (if possible) to a failed selenium operation.
+	 * 
+	 * @param shouldTake
+	 *            If <b>true</b> or <b>on</b>, a screenshot will be appended (if possible) to a failed selenium
+	 *            operation.
 	 * @return previous configuration value. If enabled will return <b>on</b>, <b>off</b> otherwise.
 	 */
 	public String setTakeScreenshotOnFailure(String shouldTake) {
-		return acceptConfigReturnPrevious(shouldTake, SeleniumFixture.WEB_DRIVER.getTakeScreenshotOnFailure(), SeleniumFixture.WEB_DRIVER::setTakeScreenshotOnFailure);
+		return acceptConfigReturnPrevious(shouldTake, SeleniumFixture.WEB_DRIVER.getTakeScreenshotOnFailure(),
+			SeleniumFixture.WEB_DRIVER::setTakeScreenshotOnFailure);
 	}
 
 	public String setDryRun(String enableDryRun) {
@@ -950,23 +1067,206 @@ public class SeleniumFixture {
 	 * </p>
 	 * Checks if a file exists in the local filesystem. Will respect wait timeout until file is available
 	 * <p>
-	 * <b>Important:</b> If you're using remote browsers such as Selenium Grid or SauceLabs, this action probably won't be useful, unless you have access to the node's remote file system.
+	 * <b>Important:</b> If you're using remote browsers such as Selenium Grid or SauceLabs, this action probably won't
+	 * be useful, unless you have access to the node's remote file system.
 	 * </p>
 	 *
-	 * @param file Path of the file to check if exists
+	 * @param file
+	 *            Path of the file to check if exists
 	 * @return if the informed file exists on the filesystem
 	 */
 	public boolean fileExists(String file) {
-		return Boolean.valueOf(SeleniumFixture.WEB_DRIVER.getWhenAvailable(file, (driver, parsedLocator) -> Boolean.toString(this.fitnesseMarkup.cleanFile(parsedLocator.getOriginalSelector()).exists())));
+		return Boolean.valueOf(SeleniumFixture.WEB_DRIVER.getWhenAvailable(file,
+			(driver, parsedLocator) -> Boolean.toString(this.fitnesseMarkup.cleanFile(parsedLocator.getOriginalSelector()).exists())));
 	}
 
+	/**
+	 * <p>
+	 * <code>
+	 * | ensure | is displayed | <i>locator</i> |
+	 * </code>
+	 * </p>
+	 * <p>
+	 * <code>
+	 * | reject | is displayed | <i>locator</i> |
+	 * </code>
+	 * </p>
+	 * Verifies that the specified element is displayed (or not).
+	 * <p>
+	 * <b>Note</b>: Wait behavior won't work properly without selenium table
+	 *
+	 * @param locator
+	 *            an element locator
+	 * @return result Boolean result indication of assertion/operation
+	 */
+	public boolean isDisplayed(String locator) {
+		return Boolean.valueOf(SeleniumFixture.WEB_DRIVER.getWhenAvailable(locator, (driver, parsedLocator) -> {
+			boolean ensuring = Boolean.valueOf(parsedLocator.getExpectedValue());
+			Optional<WebElement> element = driver.findElements(parsedLocator.getBy()).stream().filter(WebElement::isDisplayed).findFirst();
+			return Boolean.toString(ensuring == element.isPresent() ? ensuring : !ensuring);
+		}));
+	}
+
+	/**
+	 * <p>
+	 * <code>
+	 * | ensure | is enabled | <i>locator</i> |
+	 * </code>
+	 * </p>
+	 * <p>
+	 * <code>
+	 * | reject | is enabled | <i>locator</i> |
+	 * </code>
+	 * </p>
+	 * Verifies that the specified element is enabled (or not).
+	 * <p>
+	 * <b>Note</b>: Wait behavior won't work properly without selenium table
+	 *
+	 * @param locator
+	 *            an element locator
+	 * @return result Boolean result indication of assertion/operation
+	 */
+	public boolean isEnabled(String locator) {
+		return Boolean.valueOf(SeleniumFixture.WEB_DRIVER.getWhenAvailable(locator, (driver, parsedLocator) -> {
+			boolean ensuring = Boolean.valueOf(parsedLocator.getExpectedValue());
+			WebElement element = driver.findElement(parsedLocator.getBy());
+			return Boolean.toString(ensuring == element.isEnabled() ? ensuring : !ensuring);
+		}));
+	}
+
+	/**
+	 * <p>
+	 * <code>
+	 * | ensure | is selected | <i>locator</i> |
+	 * </code>
+	 * </p>
+	 * <p>
+	 * <code>
+	 * | reject | is selected | <i>locator</i> |
+	 * </code>
+	 * </p>
+	 * Verifies that the specified element is selected (or not).
+	 * <p>
+	 * <b>Note</b>: Wait behavior won't work properly without selenium table
+	 *
+	 * @param locator
+	 *            an element locator
+	 * @return result Boolean result indication of assertion/operation
+	 */
+	public boolean isSelected(String locator) {
+		return Boolean.valueOf(SeleniumFixture.WEB_DRIVER.getWhenAvailable(locator, (driver, parsedLocator) -> {
+			boolean ensuring = Boolean.valueOf(parsedLocator.getExpectedValue());
+			WebElement element = driver.findElement(parsedLocator.getBy());
+			return Boolean.toString(ensuring == element.isSelected() ? ensuring : !ensuring);
+		}));
+	}
+
+	/**
+	 * <p>
+	 * <code>
+	 * | ensure | action move to element | <i>locator</i> |
+	 * </code>
+	 * </p>
+	 * <p>
+	 * <code>
+	 * | reject | action move to element | <i>locator</i> |
+	 * </code>
+	 * </p>
+	 * Moves the mouse to the first displayed element.
+	 * <p>
+	 * <b>Note</b>: Wait behavior won't work properly without selenium table
+	 *
+	 * @param locator
+	 *            an element locator
+	 * @return result Boolean result indication of assertion/operation
+	 */
 	public boolean actionMoveToElement(String locator) {
 		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(locator, (driver, parsedLocator) -> {
-			Optional<WebElement> element = driver.findElements(parsedLocator.getBy()).stream().filter(e -> e.isDisplayed()).findFirst();
+			Optional<WebElement> element = driver.findElements(parsedLocator.getBy()).stream().filter(WebElement::isDisplayed).findFirst();
 			if (!element.isPresent()) {
 				throw new InvalidElementStateException("No displayed element found.");
 			}
 			new Actions(driver).moveToElement(element.get()).perform();
+		});
+	}
+
+	public boolean actionMoveToElementAtAnd(String locator, int xOffset, int yOffset) {
+		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(locator, (driver, parsedLocator) -> {
+			Optional<WebElement> element = driver.findElements(parsedLocator.getBy()).stream().filter(WebElement::isDisplayed).findFirst();
+			if (!element.isPresent()) {
+				throw new InvalidElementStateException("No displayed element found.");
+			}
+			new Actions(driver).moveToElement(element.get(), xOffset, yOffset).perform();
+		});
+	}
+
+	public boolean actionClick() {
+		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(StringUtils.EMPTY, (driver, parsedLocator) -> new Actions(driver).click().perform());
+	}
+
+	public boolean actionClick(String locator) {
+		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(locator, (driver, parsedLocator) -> {
+			Optional<WebElement> element = driver.findElements(parsedLocator.getBy()).stream().filter(WebElement::isDisplayed).findFirst();
+			if (!element.isPresent()) {
+				throw new InvalidElementStateException("No displayed element found.");
+			}
+			new Actions(driver).click(element.get()).perform();
+		});
+	}
+
+	public boolean actionClickAndHold() {
+		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(StringUtils.EMPTY, (driver, parsedLocator) -> new Actions(driver).clickAndHold().perform());
+	}
+
+	public boolean actionClickAndHold(String locator) {
+		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(locator, (driver, parsedLocator) -> {
+			Optional<WebElement> element = driver.findElements(parsedLocator.getBy()).stream().filter(WebElement::isDisplayed).findFirst();
+			if (!element.isPresent()) {
+				throw new InvalidElementStateException("No displayed element found.");
+			}
+			new Actions(driver).clickAndHold(element.get()).perform();
+		});
+	}
+
+	public boolean actionDoubleClick() {
+		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(StringUtils.EMPTY, (driver, parsedLocator) -> new Actions(driver).doubleClick().perform());
+	}
+
+	public boolean actionDoubleClick(String locator) {
+		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(locator, (driver, parsedLocator) -> {
+			Optional<WebElement> element = driver.findElements(parsedLocator.getBy()).stream().filter(WebElement::isDisplayed).findFirst();
+			if (!element.isPresent()) {
+				throw new InvalidElementStateException("No displayed element found.");
+			}
+			new Actions(driver).doubleClick(element.get()).perform();
+		});
+	}
+
+	public boolean actionContextClick() {
+		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(StringUtils.EMPTY, (driver, parsedLocator) -> new Actions(driver).contextClick().perform());
+	}
+
+	public boolean actionContextClick(String locator) {
+		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(locator, (driver, parsedLocator) -> {
+			Optional<WebElement> element = driver.findElements(parsedLocator.getBy()).stream().filter(WebElement::isDisplayed).findFirst();
+			if (!element.isPresent()) {
+				throw new InvalidElementStateException("No displayed element found.");
+			}
+			new Actions(driver).contextClick(element.get()).perform();
+		});
+	}
+
+	public boolean actionRelease() {
+		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(StringUtils.EMPTY, (driver, parsedLocator) -> new Actions(driver).release().perform());
+	}
+
+	public boolean actionRelease(String locator) {
+		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(locator, (driver, parsedLocator) -> {
+			Optional<WebElement> element = driver.findElements(parsedLocator.getBy()).stream().filter(WebElement::isDisplayed).findFirst();
+			if (!element.isPresent()) {
+				throw new InvalidElementStateException("No displayed element found.");
+			}
+			new Actions(driver).release(element.get()).perform();
 		});
 	}
 }

--- a/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
+++ b/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
@@ -1,38 +1,27 @@
 
 package com.github.andreptb.fitnesse;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Consumer;
-
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.ClassUtils;
-import org.apache.commons.lang3.tuple.Pair;
-import org.openqa.selenium.Dimension;
-import org.openqa.selenium.InvalidElementStateException;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.OutputType;
-import org.openqa.selenium.TakesScreenshot;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebDriver.Window;
-import org.openqa.selenium.WebDriverException;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.remote.LocalFileDetector;
-import org.openqa.selenium.remote.RemoteWebElement;
-
 import com.github.andreptb.fitnesse.selenium.BrowserDialogHelper;
 import com.github.andreptb.fitnesse.selenium.FrameWebElementHelper;
 import com.github.andreptb.fitnesse.selenium.SelectWebElementHelper;
 import com.github.andreptb.fitnesse.selenium.WebDriverHelper;
 import com.github.andreptb.fitnesse.selenium.WebDriverHelper.StopTestWithWebDriverException;
 import com.github.andreptb.fitnesse.util.FitnesseMarkup;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.openqa.selenium.*;
+import org.openqa.selenium.WebDriver.Window;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.openqa.selenium.remote.RemoteWebElement;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.NoSuchElementException;
+import java.util.function.Consumer;
 
 /**
  * Slim fixture to execute Selenium commands, see README.md for more information.

--- a/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
+++ b/src/main/java/com/github/andreptb/fitnesse/SeleniumFixture.java
@@ -1,26 +1,38 @@
 
 package com.github.andreptb.fitnesse;
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.InvalidElementStateException;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriver.Window;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.openqa.selenium.remote.RemoteWebElement;
+
 import com.github.andreptb.fitnesse.selenium.BrowserDialogHelper;
 import com.github.andreptb.fitnesse.selenium.FrameWebElementHelper;
 import com.github.andreptb.fitnesse.selenium.SelectWebElementHelper;
 import com.github.andreptb.fitnesse.selenium.WebDriverHelper;
 import com.github.andreptb.fitnesse.selenium.WebDriverHelper.StopTestWithWebDriverException;
 import com.github.andreptb.fitnesse.util.FitnesseMarkup;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang3.ClassUtils;
-import org.apache.commons.lang3.tuple.Pair;
-import org.openqa.selenium.*;
-import org.openqa.selenium.WebDriver.Window;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.remote.LocalFileDetector;
-import org.openqa.selenium.remote.RemoteWebElement;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.NoSuchElementException;
-import java.util.function.Consumer;
 
 /**
  * Slim fixture to execute Selenium commands, see README.md for more information.
@@ -957,5 +969,15 @@ public class SeleniumFixture {
 	 */
 	public boolean fileExists(String file) {
 		return Boolean.valueOf(SeleniumFixture.WEB_DRIVER.getWhenAvailable(file, (driver, parsedLocator) -> Boolean.toString(this.fitnesseMarkup.cleanFile(parsedLocator.getOriginalSelector()).exists())));
+	}
+
+	public boolean actionMoveToElement(String locator) {
+		return SeleniumFixture.WEB_DRIVER.doWhenAvailable(locator, (driver, parsedLocator) -> {
+			Optional<WebElement> element = driver.findElements(parsedLocator.getBy()).stream().filter(e -> e.isDisplayed()).findFirst();
+			if (!element.isPresent()) {
+				throw new InvalidElementStateException("No displayed element found.");
+			}
+			new Actions(driver).moveToElement(element.get()).perform();
+		});
 	}
 }

--- a/src/main/java/com/github/andreptb/fitnesse/plugins/SeleniumScriptTable.java
+++ b/src/main/java/com/github/andreptb/fitnesse/plugins/SeleniumScriptTable.java
@@ -157,7 +157,7 @@ public class SeleniumScriptTable extends ScriptTable {
 	protected List<SlimAssertion> actionAndAssign(String symbolName, int row) {
 		return super.actionAndAssign(symbolName, row).stream().map(assertion -> {
 			Optional<Instruction> instruction = SlimAssertion.getInstructions(Arrays.asList(assertion)).stream().findFirst();
-			if(instruction.isPresent()) {
+			if (instruction.isPresent()) {
 				ScreenshotEmbedderSlimExpectation expectation = new ScreenshotEmbedderSlimExpectation(assertion.getExpectation());
 				return super.makeAssertion(instruction.get(), expectation);
 			}
@@ -186,9 +186,9 @@ public class SeleniumScriptTable extends ScriptTable {
 		@Override
 		public SlimExceptionResult evaluateException(SlimExceptionResult exceptionResult) {
 			SlimExceptionResult result = this.original.evaluateException(exceptionResult);
-			if(this.original instanceof RowExpectation) {
+			if (this.original instanceof RowExpectation) {
 				String screenshot = SeleniumScriptTable.this.fitnesseMarkup.imgLinkFromExceptionMessage(exceptionResult.getException());
-				if(StringUtils.isNotBlank(screenshot)) {
+				if (StringUtils.isNotBlank(screenshot)) {
 					SeleniumScriptTable.this.getTable().addColumnToRow(((RowExpectation) this.original).getRow(), screenshot);
 				}
 			}

--- a/src/main/java/com/github/andreptb/fitnesse/selenium/BrowserDialogHelper.java
+++ b/src/main/java/com/github/andreptb/fitnesse/selenium/BrowserDialogHelper.java
@@ -1,3 +1,4 @@
+
 package com.github.andreptb.fitnesse.selenium;
 
 import java.util.function.BiFunction;

--- a/src/main/java/com/github/andreptb/fitnesse/selenium/ByWebElement.java
+++ b/src/main/java/com/github/andreptb/fitnesse/selenium/ByWebElement.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018, MP Objects, http://www.mp-objects.com
+ */
+
+package com.github.andreptb.fitnesse.selenium;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.internal.HasIdentity;
+
+import com.github.andreptb.fitnesse.SeleniumFixture;
+import com.google.common.base.Strings;
+
+/**
+ * A special selector with returns a previously retrieved element. It does perform any actual searching. The found element might no longer valid on the remote, resulting in failures when any actions
+ * are performed.
+ */
+public class ByWebElement extends By implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private String id;
+
+	private transient WebElement element;
+
+	public ByWebElement(String id) {
+		if (Strings.isNullOrEmpty(id)) {
+			throw new IllegalArgumentException("Invalid WebElement ID");
+		}
+		this.id = id;
+	}
+
+	public ByWebElement(WebElement element) {
+		this(((HasIdentity) element).getId());
+		this.element = element;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public WebElement findElement(SearchContext aContext) {
+		if (element != null) {
+			return element;
+		}
+		element = SeleniumFixture.getDriver().getCachedElement(id);
+		if (element == null) {
+			// throw exception because if it is not in the cache it will never become available anymore
+			throw new StaleElementReferenceException(String.format("Element with id %s is no longer in the locale cache.", id));
+		}
+		return element;
+	}
+
+	@Override
+	public List<WebElement> findElements(SearchContext aContext) {
+		WebElement result = findElement(aContext);
+		if (result != null) {
+			return Collections.singletonList(result);
+		} else {
+			return Collections.emptyList();
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "By.webelement: " + id;
+	}
+
+	public String toLocator() {
+		return String.format("webelement=%s", id);
+	}
+}

--- a/src/main/java/com/github/andreptb/fitnesse/selenium/SeleniumLocatorParser.java
+++ b/src/main/java/com/github/andreptb/fitnesse/selenium/SeleniumLocatorParser.java
@@ -29,7 +29,8 @@ public class SeleniumLocatorParser {
 		name(By.ByName.class),
 		css(By.ByCssSelector.class),
 		xpath(By.ByXPath.class),
-		link(By.ByLinkText.class);
+		link(By.ByLinkText.class),
+		webelement(ByWebElement.class);
 
 		private Class<? extends By> byClass;
 

--- a/src/main/java/com/github/andreptb/fitnesse/selenium/WebDriverHelper.java
+++ b/src/main/java/com/github/andreptb/fitnesse/selenium/WebDriverHelper.java
@@ -16,6 +16,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.collections.map.LRUMap;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -32,6 +33,7 @@ import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.internal.HasIdentity;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.ScreenshotException;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -82,6 +84,8 @@ public class WebDriverHelper {
 	private boolean takeScreenshotOnFailure = true;
 
 	private String dryRunWindow;
+
+	private Map<String, WebElement> cachedElements = new LRUMap(64);
 
 	/**
 	 * Creates a {@link WebDriver} instance with desired browser and capabilities. Capabilities should follow a key/value format
@@ -330,6 +334,23 @@ public class WebDriverHelper {
 
 	public void setDryRunWindow(String dryRunWindow) {
 		this.dryRunWindow = dryRunWindow;
+	}
+
+	public void clearCacheElements() {
+		cachedElements.clear();
+	}
+
+	public ByWebElement addCachedElement(WebElement element) {
+		if (element instanceof HasIdentity) {
+			ByWebElement result = new ByWebElement(element);
+			cachedElements.put(result.getId(), element);
+			return result;
+		}
+		throw new InvalidElementStateException("Element found but has no identity: " + element);
+	}
+
+	public WebElement getCachedElement(String aId) {
+		return cachedElements.get(aId);
 	}
 
 	/**

--- a/src/main/java/com/github/andreptb/fitnesse/selenium/WebDriverHelper.java
+++ b/src/main/java/com/github/andreptb/fitnesse/selenium/WebDriverHelper.java
@@ -166,7 +166,7 @@ public class WebDriverHelper {
 			}
 		}
 		String expectedValue = locator.getExpectedValue();
-		if(StringUtils.startsWith(expectedValue, FitnesseMarkup.SELECTOR_VALUE_DENY_INDICATOR)) {
+		if (StringUtils.startsWith(expectedValue, FitnesseMarkup.SELECTOR_VALUE_DENY_INDICATOR)) {
 			return WebDriverHelper.UNDEFINED_VALUE;
 		}
 		return expectedValue;

--- a/src/main/java/com/github/andreptb/fitnesse/selenium/WebDriverHelper.java
+++ b/src/main/java/com/github/andreptb/fitnesse/selenium/WebDriverHelper.java
@@ -208,7 +208,7 @@ public class WebDriverHelper {
 			wait.ignoring(UnhandledAlertException.class);
 			wait.ignoring(UnexpectedTagNameException.class);
 			try {
-				wait.until((ExpectedCondition<String>) waitingDriver -> {
+				wait.until(waitingDriver -> {
 					evaluate(waitingDriver, locator, callback, false, result);
 					return result.getValue();
 				});

--- a/src/main/java/com/github/andreptb/fitnesse/selenium/WebDriverHelper.java
+++ b/src/main/java/com/github/andreptb/fitnesse/selenium/WebDriverHelper.java
@@ -208,7 +208,7 @@ public class WebDriverHelper {
 			wait.ignoring(UnhandledAlertException.class);
 			wait.ignoring(UnexpectedTagNameException.class);
 			try {
-				wait.until(waitingDriver -> {
+				wait.until((ExpectedCondition<String>) waitingDriver -> {
 					evaluate(waitingDriver, locator, callback, false, result);
 					return result.getValue();
 				});


### PR DESCRIPTION
Guava 18 is incompatible with the newer Selenium as ```FluentWait.until(...)``` now expects a Java8 Function which Guava's Function does not extend in 18. 
With these dependency changes Guava 23.6-jre will be selected (via selenium-java).
So with these changes this fixture will work with Selenium 3.9.1 and probably also some older versions, but I could not easily find where this Guava issue popped up.

Note, to make the ```maven-classpath-plugin``` work I did have to pin the version of org.apache.maven:maven-embedder to 3.3.1 or higher due to, again Guava compatibility issues. 